### PR TITLE
Autocomplete the quattor-query command

### DIFF
--- a/src/main/cfg/bash_completion.d/ncm-query.sh
+++ b/src/main/cfg/bash_completion.d/ncm-query.sh
@@ -41,3 +41,4 @@ _ncm_query()
 }
 
 complete -F _ncm_query ncm-query
+complete -F _ncm_query quattor-query


### PR DESCRIPTION
Same autocompletion function applies to both ncm-query and quattor-query.
